### PR TITLE
feat: 메일 전송 요청 응답 및 SMTP 서버에 발송 기능 추가

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,23 @@
+const express = require('express');
+
+const index = require('./routes/index');
+
+const app = express();
+
+app.use('/', index);
+
+app.use(express.json());
+
+app.use(function (req, res, next) {
+  next(createError(404));
+});
+
+app.use(function (err, req, res) {
+  // set locals, only providing error in development
+  res.locals.message = err.message;
+  res.locals.error = req.app.get('env') === 'development' ? err : {};
+
+  res.status(err.status || 500).json(err.message);
+});
+
+module.exports = app;

--- a/app.js
+++ b/app.js
@@ -1,12 +1,13 @@
 const express = require('express');
+const createError = require('http-errors');
 
 const index = require('./routes/index');
 
 const app = express();
 
-app.use('/', index);
-
 app.use(express.json());
+
+app.use('/', index);
 
 app.use(function (req, res, next) {
   next(createError(404));

--- a/bin/www.js
+++ b/bin/www.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 
 const http = require('http');
+const debug = require('debug')('server:server');
 
 const app = require('../app');
 const config = require('../config');

--- a/bin/www.js
+++ b/bin/www.js
@@ -1,0 +1,60 @@
+require('dotenv').config();
+
+const http = require('http');
+
+const app = require('../app');
+const config = require('../config');
+
+function normalizePort(val) {
+  const port = parseInt(val, 10);
+
+  if (Number.isNaN(port)) {
+    // named pipe
+    return val;
+  }
+
+  if (port >= 0) {
+    // port number
+    return port;
+  }
+
+  return false;
+}
+
+function onListening() {
+  const addr = server.address();
+  const bind = typeof addr === 'string' ? `pipe ${addr}` : `port ${addr.port}`;
+  debug(`Listening on ${bind}`);
+}
+
+function onError(error) {
+  if (error.syscall !== 'listen') {
+    throw error;
+  }
+
+  const bind = typeof port === 'string' ? `Pipe ${port}` : `Port ${port}`;
+
+  // handle specific listen errors with friendly messages
+  switch (error.code) {
+    case 'EACCES':
+      console.error(`${bind} requires elevated privileges`);
+      process.exit(1);
+      break;
+    case 'EADDRINUSE':
+      console.error(`${bind} is already in use`);
+      process.exit(1);
+      break;
+    default:
+      throw error;
+  }
+}
+
+const port = normalizePort(config.port || '8888');
+
+app.set('port', port);
+
+const server = http.createServer(app);
+
+server.listen(port);
+server.on('error', onError);
+server.on('listening', onListening);

--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+  port: process.env.PORT,
+  smtpId: process.env.SMTP_ID,
+  smtpPassword: process.env.SMTP_PASSWORD,
+  smtpPort: process.env.SMTP_PORT,
+  smtpHost: process.env.SMTP_HOST,
+  smtpDomain: process.env.SMTP_DOMAIN,
+  mailServerApiKey: process.env.MAIL_SERVER_API_KEY
+};

--- a/constants/index.js
+++ b/constants/index.js
@@ -1,0 +1,3 @@
+exports.ERROR_MESSAGE = {
+  INVALID_API_KEY: '인증되지 않은 API_KEY 입니다',
+};

--- a/nodeMailer/index.js
+++ b/nodeMailer/index.js
@@ -8,13 +8,12 @@ const {
   smtpDomain,
 } = require('../config');
 
-exports.sendMail = async function ({
+exports.sendMail = async function (
   emailTitle,
   emailContent,
   sender,
   recipientAddress,
-  userName,
-}) {
+) {
   const transporter = nodemailer.createTransport({
     host: smtpHost,
     port: smtpPort,
@@ -26,11 +25,13 @@ exports.sendMail = async function ({
   });
 
   const info = await transporter.sendMail({
-    from: `${sender || userName} <${smtpId}@${smtpDomain}>`,
+    from: `${sender} <${smtpId}@${smtpDomain}>`,
     to: recipientAddress,
     subject: emailTitle,
     html: emailContent,
   });
+
+  transporter.close();
 
   return info;
 };

--- a/nodeMailer/index.js
+++ b/nodeMailer/index.js
@@ -1,0 +1,36 @@
+const nodemailer = require('nodemailer');
+
+const {
+  smtpPort,
+  smtpId,
+  smtpPassword,
+  smtpHost,
+  smtpDomain,
+} = require('../config');
+
+exports.sendMail = async function ({
+  emailTitle,
+  emailContent,
+  sender,
+  recipientAddress,
+  userName,
+}) {
+  const transporter = nodemailer.createTransport({
+    host: smtpHost,
+    port: smtpPort,
+    secure: smtpPort === '465',
+    auth: {
+      user: smtpId,
+      pass: smtpPassword,
+    },
+  });
+
+  const info = await transporter.sendMail({
+    from: `${sender || userName} <${smtpId}@${smtpDomain}>`,
+    to: recipientAddress,
+    subject: emailTitle,
+    html: emailContent,
+  });
+
+  return info;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
+        "http-errors": "^2.0.0",
         "nodemailer": "^6.9.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
+    "http-errors": "^2.0.0",
     "nodemailer": "^6.9.1"
   }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,7 +2,8 @@ const express = require('express');
 const router = express.Router();
 
 const { verifyApiKey } = require('./middlewares/verifyApiKey');
+const { sendMail } = require('./middlewares/sendMail');
 
-router.post(`/users/:api_key/sending-email`, verifyApiKey);
+router.post(`/users/:api_key/sending-email`, verifyApiKey, sendMail);
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,0 +1,4 @@
+const express = require('express');
+const router = express.Router();
+
+router.post(`/users/:api_key/sending-email`);

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,4 +1,8 @@
 const express = require('express');
 const router = express.Router();
 
-router.post(`/users/:api_key/sending-email`);
+const { verifyApiKey } = require('./middlewares/verifyApiKey');
+
+router.post(`/users/:api_key/sending-email`, verifyApiKey);
+
+module.exports = router;

--- a/routes/middlewares/sendMail.js
+++ b/routes/middlewares/sendMail.js
@@ -1,0 +1,24 @@
+const { sendMail } = require("../../nodeMailer");
+
+exports.sendMail = async function (req, res, next) {
+  const {
+    sender,
+    emailTitle,
+    emailContent,
+    recipients,
+  } = req.body;
+
+  try {
+    const sendResults = await Promise.allSettled(recipients.map(recipient => sendMail(emailTitle, emailContent, sender, recipient)));
+
+    const totalSendCount = sendResults.length;
+    const successSendCount = sendResults.filter(sendResult => sendResult.status === 'fulfilled').length;
+
+    res.json({
+      totalSendCount,
+      successSendCount
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/routes/middlewares/verifyApiKey.js
+++ b/routes/middlewares/verifyApiKey.js
@@ -3,8 +3,6 @@ const createError = require('http-errors');
 const { ERROR_MESSAGE } = require("../../constants");
 
 exports.verifyApiKey = function (req, res, next) {
-  console.log(req.params.api_key);
-
   if (req.params.api_key !== mailServerApiKey) {
     return next(createError(401, ERROR_MESSAGE.INVALID_API_KEY));
   }

--- a/routes/middlewares/verifyApiKey.js
+++ b/routes/middlewares/verifyApiKey.js
@@ -1,0 +1,13 @@
+const { mailServerApiKey } = require("../../config");
+const createError = require('http-errors');
+const { ERROR_MESSAGE } = require("../../constants");
+
+exports.verifyApiKey = function (req, res, next) {
+  console.log(req.params.api_key);
+
+  if (req.params.api_key !== mailServerApiKey) {
+    return next(createError(401, ERROR_MESSAGE.INVALID_API_KEY));
+  }
+
+  next();
+};


### PR DESCRIPTION
## 변경사항
1. ez-mail 백엔드 서버로부터 메일 전송 요청을 받는 기능을 추가했습니다.
2. 이미 구축되어있는 SMTP 서버에 메일 발송을 요청하는 기능을 추가했습니다.
3. Promise.allSettled 를 이용해 여러 이메일 전송을 해야할 때 싱글스레드 기반이더라도 시간이 단축되도록 구현했습니다.

## 추후 개선 사항
1. 초기엔 SMTP 응답을 받고 SMTP 요청을 하는 자체 메일서버를 구축하려했으나 프로젝트 남은 기간까지 구현이 힘들다 판단하여 아마존 SES 나 sendgrid 같은 http 요청을 받고 이메일 발송을 해주는 서버를 모티브로 구축했습니다.